### PR TITLE
Ensure deeply nested lists are traversed even if the parent is OK.

### DIFF
--- a/schematics_xml/models.py
+++ b/schematics_xml/models.py
@@ -184,10 +184,16 @@ def ensure_lists_in_model(raw_data: dict, model_cls: XMLModel):
 
 def ensure_lists_in_value(value: 'typing.Any', field: BaseType):
 
-    if isinstance(field, ListType) and not isinstance(value, list):
-        value = [
-            ensure_lists_in_value(value, field.field)
-        ]
+    if isinstance(field, ListType):
+        if not isinstance(value, list):
+            value = [
+                ensure_lists_in_value(value, field.field)
+            ]
+        elif field_has_type(ListType, field.field):
+            value = [
+                ensure_lists_in_value(_value, field.field)
+                for _value in value
+            ]
 
     elif field_has_type(ListType, field):
         if isinstance(field, DictType):

--- a/schematics_xml/tests/test_models.py
+++ b/schematics_xml/tests/test_models.py
@@ -870,27 +870,29 @@ class TestEnsureLists:
 
     def test_model_with_listtype_of_modeltype_with_listtype_of_modeltype(self):  # pylint: disable=no-self-use,invalid-name
         """
-        Test that a model with a list type of models can correctly be
+        Test that a model with a list type of models are correctly converted.
+
+        This test also tests the serialized_name functionality of schematics.
         """
         class Item(XMLModel):
             number = IntType()
 
         class Package(XMLModel):
-            items = ListType(ModelType(Item))
+            items = ListType(ModelType(Item), serialized_name='contents')
 
         class TestModel(XMLModel):
-            packages = ListType(ModelType(Package))
+            packages = ListType(ModelType(Package), serialized_name='pkg')
 
         bad_data = dict(
-            packages=dict(
-                items=dict(number=1)
+            pkg=dict(
+                contents=dict(number=1)
             )
         )
         actual = ensure_lists_in_model(bad_data, TestModel)
         expected = dict(
-            packages=[
+            pkg=[
                 dict(
-                    items=[
+                    contents=[
                         dict(number=1)
                     ]
                 )
@@ -901,6 +903,17 @@ class TestEnsureLists:
 
         actual = ensure_lists_in_model(expected, TestModel)
         # Assert good data stays good
+        assert actual == expected
+
+        # Assert data is traversed even if the parent is OK.
+        bad_data = dict(
+            pkg=[
+                dict(
+                    contents=dict(number=1)
+                )
+            ]
+        )
+        actual = ensure_lists_in_model(bad_data, TestModel)
         assert actual == expected
 
     def test_model_with_modeltype_with_listtype_of_modeltype(self):  # pylint: disable=no-self-use,invalid-name


### PR DESCRIPTION
If a parent list is OK `ensure_lists_in_value` was not traversing into the data and finding deeply nested data that also needed to be converted to a list.

Also features test for schematics `serialized_name` `BaseType` feature.