### PR TITLE
Ensure that lists with `None` value aren't turned into `[None]`

### DIFF
--- a/schematics_xml/models.py
+++ b/schematics_xml/models.py
@@ -191,6 +191,10 @@ def ensure_lists_in_model(raw_data: dict, model_cls: XMLModel):
 
 def ensure_lists_in_value(value: 'typing.Any', field: BaseType):
 
+    if value is None:
+        # Don't turn None items into a list of None items
+        return None
+
     if isinstance(field, ListType):
         if not isinstance(value, list):
             value = [

--- a/schematics_xml/tests/test_models.py
+++ b/schematics_xml/tests/test_models.py
@@ -842,6 +842,40 @@ class TestEnsureLists:
         # Assert good data stays good
         assert actual == expected
 
+    def test_model_with_listtype_of_none(self):  # pylint: disable=no-self-use,invalid-name
+        """
+        Ensure a model with a list type that has a value of None isn't turned into ``[None]``.
+        """
+        class TestModel(XMLModel):
+            numbers = ListType(IntType())
+
+        bad_data = dict(numbers=None)
+        actual = ensure_lists_in_model(bad_data, TestModel)
+        expected = dict(numbers=None)
+        # Assert bad data can be turned good
+        assert actual == expected
+
+        actual = ensure_lists_in_model(expected, TestModel)
+        # Assert good data stays good
+        assert actual == expected
+
+    def test_model_with_listtype_of_mixed_value(self):  # pylint: disable=no-self-use,invalid-name
+        """
+        Ensure a model with a list type that has a value ``[1, None]`` is handled correctly.
+        """
+        class TestModel(XMLModel):
+            numbers = ListType(IntType())
+
+        bad_data = dict(numbers=[1, None])
+        actual = ensure_lists_in_model(bad_data, TestModel)
+        expected = dict(numbers=[1, None])
+        # Assert bad data can be turned good
+        assert actual == expected
+
+        actual = ensure_lists_in_model(expected, TestModel)
+        # Assert good data stays good
+        assert actual == expected
+
     def test_model_with_listtype_of_modeltype(self):  # pylint: disable=no-self-use,invalid-name
         """
         Test that a model with a list type of models can correctly be


### PR DESCRIPTION
Stop `None` values for a list being turned into `[None]`.